### PR TITLE
Shrink WASM binary output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2018"
 [dependencies]
 stdweb = "0.4"
 yew = { git = "https://github.com/DenisKolodin/yew" }
+
+[profile.release]
+lto = true
+opt-level = 's'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,30 @@ Use your device's camera to run object detection on the world around you.
 
 [You can see a demo here](https://vision.prawn.farm)
 
-## Developer Usage
+## Building the app
+
+You need to install [binaryen](https://github.com/WebAssembly/binaryen) in order to have
+access to `wasm-opt`, which will help to shirkn the final
+size of the wasm binary.
+
+Through a combination of building in release mode, compiling
+with Link Time Optimizations (LTO), telling LLVM to optimize
+for size instead of speed, and running `wasm-opt`, we can
+reduce the size of the final wasm binary by as much as 80%.
+
+We recommend reading https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size for additional information.
+
+See [our build script](build.sh) for the exact commands
+that we use to build the application.
+
+See the `[profile.release]` section of [Cargo.toml](Cargo.toml) to
+take a look at the LLVM optimizations used during the build.
+
+### Development Mode
+
+The following command will keep a copy of the app
+running locally, if you want to play
+around with the code.
 
 ```sh
 cargo web start --target=wasm32-unknown-unknown

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-cargo web build --target=wasm32-unknown-unknown
+cargo web build --target=wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/debug/vision.wasm static/.
 cp target/wasm32-unknown-unknown/debug/vision.js static/.

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 cargo web build --target=wasm32-unknown-unknown --release
-cp target/wasm32-unknown-unknown/debug/vision.wasm static/.
-cp target/wasm32-unknown-unknown/debug/vision.js static/.
+cp target/wasm32-unknown-unknown/release/vision.wasm static/.
+cp target/wasm32-unknown-unknown/release/vision.js static/.
+wasm-opt -Os -o static/vision-min.wasm static/vision.wasm
+mv static/vision-min.wasm static/vision.wasm
+


### PR DESCRIPTION
We set the appropriate LLVM options to shrink WASM binary output, adjusted the build script to output release mode binaries, and added an invocation of `wasm-opt` to the build script.  This resulted in a WASM output of size 117K, where the original debug build was 1039K.