### PR TITLE
Fix coco version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vision"
-version = "0.3.1"
+version = "0.3.2-coco-puffed"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 edition = "2018"
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,42 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>vision</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <style>
-            #container {
-                height: 100%;
-                position: relative;
-                width: 100%;
-            }
 
-            html, body, canvas {
-                margin: 0px;
-                padding: 0px;
-                width: 100%;
-                height: 100%;
-                overflow: hidden;
-            }
+<head>
+    <meta charset="utf-8">
+    <title>vision</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        #container {
+            height: 100%;
+            position: relative;
+            width: 100%;
+        }
 
-            #download-button {
-                bottom: 0;
-                left: 0;
-                position: absolute;
-                width: 128px;
-                height: 128px;
-            }
-        </style>
-        <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-        <script src="draw.js"></script>
-        <!-- tensorflow.js version 0.14.2 caused some int/float
+        html,
+        body,
+        canvas {
+            margin: 0px;
+            padding: 0px;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+
+        #download-button {
+            bottom: 0;
+            left: 0;
+            position: absolute;
+            width: 128px;
+            height: 128px;
+        }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="draw.js"></script>
+    <!-- tensorflow.js version 0.14.2 caused some int/float
              type conversion errors when executing the model,
              so we've forced a lower version here -->
-        <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.14.1"> </script>
-        <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd"> </script>
-    </head>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.14.1"> </script>
+    <!-- we need coco 0.1.1 since we're using TFJS < 1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd@0.1.1"> </script>
+</head>
 
-    <body>   
-        <script src="vision.js"></script>
-    </body>
+<body>
+    <script src="vision.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Processing didn't work after COCO-SSD bumped to version 1.0 automatically.  We fixed the version to 0.1.1 to resolve this.